### PR TITLE
Add WSL detection in order to deactivate systemd_interval configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "tokio",
  "users",
  "which",
+ "wsl",
 ]
 
 [[package]]
@@ -1498,3 +1499,9 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ which = "4.0"
 dirs = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+wsl="0.1"
 
 [dependencies.ctrlc]
 git = "https://github.com/mettke/rust-ctrlc"

--- a/src/php/server_fpm.rs
+++ b/src/php/server_fpm.rs
@@ -11,6 +11,8 @@ use crate::{php::structs::PhpServerSapi};
 use crate::utils::network::find_available_port;
 use std::process::Child;
 
+use wsl::is_wsl;
+
 // Possible values: alert, error, warning, notice, debug
 #[cfg(not(target_family = "windows"))]
 const FPM_DEFAULT_LOG_LEVEL: &str = "notice";
@@ -82,7 +84,7 @@ pub(crate) fn start(php_bin: String) -> (PhpServer, Child) {
     let port = find_available_port(FPM_DEFAULT_PORT);
 
     // TODO systemd support should be detected dynamically on Linux
-    let systemd_support = !cfg!(target_os = "macos");
+    let systemd_support = !cfg!(target_os = "macos") && !is_wsl();
 
     let config = FPM_DEFAULT_CONFIG
         .replace("{{ uid }}", uid_str.as_str())

--- a/src/php/server_fpm.rs
+++ b/src/php/server_fpm.rs
@@ -11,6 +11,7 @@ use crate::{php::structs::PhpServerSapi};
 use crate::utils::network::find_available_port;
 use std::process::Child;
 
+#[cfg(not(target_family = "windows"))]
 use wsl::is_wsl;
 
 // Possible values: alert, error, warning, notice, debug


### PR DESCRIPTION
Fixes #12 

I wasn't able to `cargo install wsl` due to an error (`error: specified package `wsl v0.1.0` has no binaries`) even though [this page exists](https://docs.rs/wsl/0.1.0/wsl/).

Sorry for the delay. 