### PR TITLE
PHP List: change the column separator and bodrer

### DIFF
--- a/src/commands/php_list.rs
+++ b/src/commands/php_list.rs
@@ -17,8 +17,8 @@ pub(crate) fn php_list() {
 
     let mut table = Table::new();
     let format = format::FormatBuilder::new()
-        .column_separator('|')
-        .borders('|')
+        .column_separator('│')
+        .borders('│')
         .separators(
             &[format::LinePosition::Top],
             format::LineSeparator::new('─', '┬', '┌', '┐'),


### PR DESCRIPTION
This change to use the long pipe char instead of standard pipe in the `php:list` command.