### PR TITLE
write fpm config file if not yet existing

### DIFF
--- a/src/php/server_fpm.rs
+++ b/src/php/server_fpm.rs
@@ -108,9 +108,11 @@ pub(crate) fn start(php_bin: String) -> (PhpServer, Child) {
         panic!("Cannot find the \"HOME\" directory in which to write the php-fpm configuration file.");
     }
 
-    // let mut fpm_config_file = File::create(&fpm_config_file_path).unwrap();
-    // fpm_config_file.write_all(config.as_bytes())
-    //     .expect("Could not write to php-fpm config file.");
+    if !fpm_config_file_path.exists() {
+        let mut fpm_config_file = File::create(&fpm_config_file_path).unwrap();
+        fpm_config_file.write_all(config.as_bytes())
+             .expect("Could not write to php-fpm config file.");
+    }
 
     let cwd = env::current_dir().unwrap();
     let pid_filename = format!("{}/.fpm.pid", cwd.to_str().unwrap());


### PR DESCRIPTION
Currently the server won't start if the fpm config is not existing.

And it is not automatically created (you removed the code in [this commit](https://github.com/Orbitale/Rymfony/commit/34589efcd1618212c52711852e9b7418347d3906)).

I added a file exists check, so we (the users) can manually change the config for testing.