### PR TITLE
add HTTPS=On header if TLS is used

### DIFF
--- a/src/http/fastcgi_handler.rs
+++ b/src/http/fastcgi_handler.rs
@@ -22,6 +22,7 @@ pub(crate) async fn handle_fastcgi(
     req: Request<Body>,
     http_port: &u16,
     php_port: &u16,
+    use_tls: bool,
 ) -> Result<Response<Body>, Infallible> {
     let document_root = String::from(document_root);
     let php_entrypoint_file = String::from(php_entrypoint_file);
@@ -94,6 +95,11 @@ pub(crate) async fn handle_fastcgi(
 
         fcgi_headers_normalized.push((header_name, value.to_str().unwrap()));
     }
+
+    if use_tls {
+        fcgi_headers_normalized.push(("HTTPS".to_string(), "On"));
+    }
+
     fcgi_params.extend(fcgi_headers_normalized.iter().map(|(k, s)| (k.as_str(), *s)));
 
     let request_body_bytes = hyper::body::to_bytes(request_body).await.unwrap();

--- a/src/http/proxy_server.rs
+++ b/src/http/proxy_server.rs
@@ -36,7 +36,7 @@ pub(crate) async fn start(
     let document_root = document_root.clone();
     let php_entrypoint_file = php_entrypoint_file.clone();
 
-    let mut routes = warp::any()
+    let routes = warp::any()
         .and(warp::addr::remote())
         .and(method())
         .and(warp::path::full())
@@ -56,6 +56,11 @@ pub(crate) async fn start(
             let document_root = document_root.clone();
             let php_entrypoint_file = php_entrypoint_file.clone();
             let method = method.clone();
+
+            let mut req_headers = headers.clone();
+            if forward_http_to_https {
+                req_headers.insert("X-Forwarded-Proto", "https".parse().unwrap());
+            }
 
             async move {
                 let query_string: String = query.iter()
@@ -79,7 +84,7 @@ pub(crate) async fn start(
                     .uri(&request_uri)
                     .body(Body::from(body))
                     .unwrap();
-                { *req.headers_mut() = headers; }
+                { *req.headers_mut() = req_headers; }
 
                 let render_static = get_render_static_path(&document_root, &request_path);
                 let render_static = !request_path.contains(".php")

--- a/src/http/proxy_server.rs
+++ b/src/http/proxy_server.rs
@@ -57,11 +57,6 @@ pub(crate) async fn start(
             let php_entrypoint_file = php_entrypoint_file.clone();
             let method = method.clone();
 
-            let mut req_headers = headers.clone();
-            if forward_http_to_https {
-                req_headers.insert("X-Forwarded-Proto", "https".parse().unwrap());
-            }
-
             async move {
                 let query_string: String = query.iter()
                     .map(|(key, value)| {
@@ -84,7 +79,7 @@ pub(crate) async fn start(
                     .uri(&request_uri)
                     .body(Body::from(body))
                     .unwrap();
-                { *req.headers_mut() = req_headers; }
+                { *req.headers_mut() = headers; }
 
                 let render_static = get_render_static_path(&document_root, &request_path);
                 let render_static = !request_path.contains(".php")
@@ -114,6 +109,7 @@ pub(crate) async fn start(
                             req,
                             &http_port,
                             &php_port,
+                            use_tls
                         )
                             .await
                     }


### PR DESCRIPTION
Follow up on #32

After building the latest version I had quite some troubles reaching my Symfony app, due to redirects to http.

Fast forward 2 hours and a lot of try&error I found the problem in the missing `HTTPS`=`On` header.

Seems this is the de-facto standard to detect if PHP was called via http or https and Symfony calculates the protocol for routes by this header.

My app authentication is still broken, but thats a topic for another day.