### PR TITLE
Add 'server' header on HTTP response

### DIFF
--- a/src/http/fastcgi_handler.rs
+++ b/src/http/fastcgi_handler.rs
@@ -207,8 +207,6 @@ pub(crate) async fn handle_fastcgi(
         .status(status_code)
         .body(response_body)
         .unwrap();
-    
-    response.headers_mut().insert("server", "Rymfony".parse().unwrap());
 
     trace!("Finish response");
 

--- a/src/http/fastcgi_handler.rs
+++ b/src/http/fastcgi_handler.rs
@@ -168,8 +168,6 @@ pub(crate) async fn handle_fastcgi(
             )
         })
         .collect();
-    headers_normalized.insert(HeaderName::from_bytes("server".as_bytes()).unwrap(), HeaderValue::from_str("rymfony").unwrap());
-    
     debug!("Response headers are now normalized");
     let (_, body) = fcgi_stdout.split_at(headers_len);
 
@@ -205,10 +203,12 @@ pub(crate) async fn handle_fastcgi(
     let response_headers = response_builder.headers_mut().unwrap();
     response_headers.extend(headers_normalized);
 
-    let response = response_builder
+    let mut response = response_builder
         .status(status_code)
         .body(response_body)
         .unwrap();
+    
+    response.headers_mut().insert("server", "Rymfony".parse().unwrap());
 
     trace!("Finish response");
 

--- a/src/http/fastcgi_handler.rs
+++ b/src/http/fastcgi_handler.rs
@@ -168,6 +168,8 @@ pub(crate) async fn handle_fastcgi(
             )
         })
         .collect();
+    headers_normalized.insert(HeaderName::from_bytes("server".as_bytes()).unwrap(), HeaderValue::from_str("rymfony").unwrap());
+    
     debug!("Response headers are now normalized");
     let (_, body) = fcgi_stdout.split_at(headers_len);
 

--- a/src/http/proxy_server.rs
+++ b/src/http/proxy_server.rs
@@ -30,6 +30,7 @@ pub(crate) async fn start(
     php_port: u16,
     document_root: String,
     php_entrypoint_file: String,
+    add_server_sign: bool,
 ) {
     let http_port = http_port.clone();
     let php_port = php_port.clone();
@@ -114,7 +115,9 @@ pub(crate) async fn start(
                             .await
                     }
                     ;
-                response.as_mut().unwrap().headers_mut().append("server", "Rymfony".parse().unwrap());
+                if add_server_sign {
+                    response.as_mut().unwrap().headers_mut().append("server", "Rymfony".parse().unwrap());
+                }
 
                 response
             }

--- a/src/http/proxy_server.rs
+++ b/src/http/proxy_server.rs
@@ -94,7 +94,7 @@ pub(crate) async fn start(
                     if render_static { " (static)" } else { "" }
                 );
 
-                let response =
+                let mut response =
                     if render_static {
                         serve_static(req, Static::new(Path::new(&document_root))).await
                     } else {
@@ -114,6 +114,7 @@ pub(crate) async fn start(
                             .await
                     }
                     ;
+                response.as_mut().unwrap().headers_mut().append("server", "rymfony".parse().unwrap());
 
                 response
             }

--- a/src/http/proxy_server.rs
+++ b/src/http/proxy_server.rs
@@ -114,7 +114,7 @@ pub(crate) async fn start(
                             .await
                     }
                     ;
-                response.as_mut().unwrap().headers_mut().append("server", "rymfony".parse().unwrap());
+                response.as_mut().unwrap().headers_mut().append("server", "Rymfony".parse().unwrap());
 
                 response
             }


### PR DESCRIPTION
The result on cURL wit PHP-FPM.

```
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Connection state changed (MAX_CONCURRENT_STREAMS == 4294967295)!
< HTTP/2 200 
< x-some-random-header: some-random-value
< content-length: 976
< content-type: text/plain;charset=UTF-8
< server: Rymfony
< date: Thu, 03 Dec 2020 22:31:35 GMT
< 
Hey! It works!
```