### PR TITLE
use php-versions.json file to load php version list

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ To do (order of priority, done first):
             - 💡 Please [suggest](https://github.com/Pierstoval/rymfony/issues/new) more places where PHP could be present!
         - 🟩 Flag the current path-based `php` script to check its version and mark it as "System" (just like in Symfony CLI)
         - 🟩 Store a list of all PHP binaries in `~/.rymfony/php_versions.json`
-        - 🟥 Deserialize the `php-versions.json` config file if it exists when using `binaries::all()` or `binaries::current()` to make the command faster
+        - 🟩 Deserialize the `php-versions.json` config file if it exists when using `binaries::all()` or `binaries::current()` to make the command faster
         - 🟥 Add an option to the `php:list` command such as `--refresh` that will make another lookup and save the `~/.rymfony/php-versions.json` file again 😄
         - 🟥 Implement a way to retrieve the current PHP version based on a local `.php-version` file
     - 🟥 Allow passing environment variables to PHP via an `-e|--env` option.

--- a/src/commands/php_list.rs
+++ b/src/commands/php_list.rs
@@ -20,7 +20,7 @@ pub(crate) fn php_list(args: &ArgMatches) {
 
     if args.is_present("refresh") {
         match clear_binaries_list() {
-            Ok(_) => info!("Binary cache successfully cleared!"),
+            Ok(_) => info!("Binaries cache successfully cleared!"),
             Err(e) => error!("Could not clear binaries cache: {}", e)
         }
     }

--- a/src/commands/php_list.rs
+++ b/src/commands/php_list.rs
@@ -1,16 +1,30 @@
-use clap::App;
+use clap::{App, Arg, ArgMatches};
 use clap::SubCommand;
 use prettytable::format;
 use prettytable::Table;
 
 use crate::php;
-use crate::config::config::save_binaries_to_config;
+use crate::config::config::{save_binaries_to_config, clear_binaries_list};
 
 pub(crate) fn command_config<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("php:list").about("List all available PHP executables")
+        .arg(
+            Arg::with_name("refresh")
+                .short("r")
+                .long("refresh")
+                .help("Refresh the PHP list cache"),
+        )
 }
 
-pub(crate) fn php_list() {
+pub(crate) fn php_list(args: &ArgMatches) {
+
+    if args.is_present("refresh") {
+        match clear_binaries_list() {
+            Ok(_) => info!("Cache cleared"),
+            Err(e) => error!("Error on clear cache : {}", e)
+        }
+    }
+
     let binaries = php::binaries::all();
 
     save_binaries_to_config(&binaries);

--- a/src/commands/php_list.rs
+++ b/src/commands/php_list.rs
@@ -20,8 +20,8 @@ pub(crate) fn php_list(args: &ArgMatches) {
 
     if args.is_present("refresh") {
         match clear_binaries_list() {
-            Ok(_) => info!("Cache cleared"),
-            Err(e) => error!("Error on clear cache : {}", e)
+            Ok(_) => info!("Binary cache successfully cleared!"),
+            Err(e) => error!("Could not clear binaries cache: {}", e)
         }
     }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -12,7 +12,7 @@ struct ConfigError(String);
 
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "There is an error: {}", self.0)
+        write!(f, "An error occured: {}", self.0)
     }
 }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -2,8 +2,21 @@ use std::collections::HashMap;
 use crate::php::structs::PhpVersion;
 use crate::php::structs::PhpBinary;
 use dirs::home_dir;
-use std::fs::File;
+use std::fs::{File, read_to_string, remove_file};
 use std::io::Write;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+struct ConfigError(String);
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "There is an error: {}", self.0)
+    }
+}
+
+impl Error for ConfigError {}
 
 pub(crate) fn save_binaries_to_config(binaries: &HashMap<PhpVersion, PhpBinary>) {
     let serialized = serde_json::to_string_pretty(&binaries).unwrap();
@@ -14,4 +27,27 @@ pub(crate) fn save_binaries_to_config(binaries: &HashMap<PhpVersion, PhpBinary>)
 
     versions_file.write_all(serialized.as_bytes())
         .expect("Could not write PHP versions to JSON file.");
+}
+
+pub(crate) fn load_binaries_from_config() -> std::result::Result<HashMap<PhpVersion, PhpBinary>, Box<dyn std::error::Error>> {
+
+    let versions_file_path = home_dir().unwrap().join(".rymfony").join("php-versions.json");
+
+    if !versions_file_path.exists() {
+        return Err(Box::new(ConfigError("No file found".into())));
+    }
+    trace!("File {} found", versions_file_path.to_str().unwrap());
+
+    let binaries: HashMap<PhpVersion, PhpBinary> = serde_json::from_str(read_to_string(&versions_file_path).unwrap().as_str()).expect("Unable to unserialize data");
+
+    Ok(binaries)
+}
+
+pub(crate) fn clear_binaries_list() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let versions_file_path = home_dir().unwrap().join(".rymfony").join("php-versions.json");
+
+    if versions_file_path.exists() {
+        remove_file(&versions_file_path).expect(format!("Unable to remove cache file {}", versions_file_path.to_str().unwrap()).as_str());
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ https://github.com/Orbitale/Rymfony
         Some("new:symfony") => crate::commands::new_symfony::new_symfony(
             matches.subcommand_matches("new:symfony").unwrap(),
         ),
-        Some("php:list") => crate::commands::php_list::php_list(),
+        Some("php:list") => crate::commands::php_list::php_list(matches.subcommand_matches("php:list").unwrap()),
         _ => {
             // If no subcommand is specified,
             // re-run the program with "--help"

--- a/src/php/binaries.rs
+++ b/src/php/binaries.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 use crate::php::structs::PhpBinary;
 use crate::php::structs::PhpServerSapi;
 use crate::php::structs::PhpVersion;
+use crate::config::config::load_binaries_from_config;
 
 pub(crate) fn current() -> String {
     let _binaries = all();
@@ -27,6 +28,14 @@ pub(crate) fn current() -> String {
 }
 
 pub(crate) fn all() -> HashMap<PhpVersion, PhpBinary> {
+    let load_infos = load_binaries_from_config();
+    return match load_infos {
+        Ok(data) => data,
+        Err(_) => get_all(),
+    }
+}
+
+fn get_all() -> HashMap<PhpVersion, PhpBinary> {
     let mut binaries: HashMap<PhpVersion, PhpBinary> = HashMap::new();
 
     binaries_from_env(&mut binaries);


### PR DESCRIPTION
> Deserialize the `php-versions.json` config file if it exists when using `binaries::all()` or `binaries::current()` to make the command faster
> Add an option to the `php:list` command such as `--refresh` that will make another lookup and save the `~/.rymfony/php-versions.json` file again 😄