### PR TITLE
Use only TcpStream and update FPM config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "loom",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +411,18 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -577,6 +624,19 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi",
 ]
 
 [[package]]
@@ -875,6 +935,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +956,15 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+dependencies = [
+ "autocfg 1.0.1",
+]
 
 [[package]]
 name = "mime"
@@ -1431,6 +1511,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg 1.0.1",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1650,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1697,8 @@ dependencies = [
  "runas",
  "serde",
  "serde_json",
+ "sha2",
+ "sysinfo",
  "tokio",
  "tokio-native-tls",
  "urldecode",
@@ -1660,6 +1776,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "serde"
 version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1859,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1925,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.15.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de94457a09609f33fec5e7fceaf907488967c6c7c75d64da6a7ce6ffdb8b5abd"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "doc-comment",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ which = "4.0"
 warp = { version = "0.3", features = ["tls"]}
 wsl="0.1"
 runas = "0.2.1"
+sha2 = "0.9.2"
+sysinfo = "0.15.3"
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 users = "0.10"

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ To do (order of priority, done first):
     - 🟥 Allow passing a custom option to specify which method the user wants to use to start PHP (like `--use-fpm` or `--use-native`, something like that).
     - 🟥 (utopia) Support setups that have multiple PHP versions installed (such as on Ubuntu/Debian with deb-sury's repo, or with Homebrew on OSX), and allow customizing the version.
     - PHP Server
-        - 🟥 Don't rewrite the `fpm-conf.ini` configuration file each time a server is launched.
+        - 🟩 Don't rewrite the `fpm-conf.ini` configuration file each time a server is launched.
         - 🟥 Find a way to differenciate servers configurations, in case multiple servers are started
 - Going way further
     - 🟥 (utopia) Detect whether the project uses Docker Compose

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::fs::File;
+use std::fs::{File, read_to_string};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
@@ -9,14 +9,16 @@ use clap::Arg;
 use clap::ArgMatches;
 use clap::SubCommand;
 use log::info;
+use sysinfo::{get_current_pid, SystemExt, ProcessExt};
 
 use crate::http::proxy_server;
 use crate::php::php_server;
 use crate::php::php_server::PhpServer;
-use crate::php::structs::PhpServerSapi;
+use crate::php::structs::{PhpServerSapi, ServerInfo};
 use crate::utils::current_process_name;
 use crate::utils::network::find_available_port;
 use crate::utils::network::parse_default_port;
+use crate::utils::project_directory::get_rymfony_project_directory;
 
 const DEFAULT_PORT: &str = "8000";
 
@@ -77,7 +79,35 @@ pub(crate) fn serve(args: &ArgMatches) {
 }
 
 fn serve_foreground(args: &ArgMatches) {
-    let port = find_available_port(parse_default_port(args.value_of("port").unwrap_or(DEFAULT_PORT), DEFAULT_PORT));
+    let path = get_rymfony_project_directory().unwrap();
+    let rymfony_pid_file = path.join("rymfony.pid");
+    debug!("Looking for PID file in \"{}\".", rymfony_pid_file.to_str().unwrap());
+    if rymfony_pid_file.exists() {
+        // Check if process is rymfony and exit if true.
+
+        let infos: ServerInfo = serde_json::from_str(read_to_string(&rymfony_pid_file).unwrap().as_str()).expect("Unable to unserialize data from PID file.");
+
+        let mut system = sysinfo::System::new_all();
+        system.refresh_all();
+        for (pid, proc_) in system.get_processes() {
+            #[cfg(not(target_family = "windows"))]
+                let process_pid = *pid;
+
+            #[cfg(target_family = "windows")]
+                let process_pid = *pid as i32;
+
+            let mut pname = proc_.exe().to_str().unwrap();
+            let pname_lower = pname.to_lowercase();
+            pname = pname_lower.as_str();
+
+            let exe_rymfony_name = if cfg!(not(target_family = "windows")) { "rymfony" } else { "rymfony.exe" };
+
+            if &process_pid == &infos.pid() && pname.ends_with(exe_rymfony_name) {
+                info!("The server is already running and listening to {}://127.0.0.1:{}", infos.scheme(), infos.port());
+                return;
+            }
+        }
+    }
 
     let mut document_root = get_document_root(args.value_of("document-root").unwrap_or("").to_string());
     if document_root.ends_with('/') { document_root.pop(); }
@@ -135,6 +165,26 @@ fn serve_foreground(args: &ArgMatches) {
 
     info!("Configured document root: {}", &document_root);
 
+    let port = find_available_port(parse_default_port(args.value_of("port").unwrap_or(DEFAULT_PORT), DEFAULT_PORT));
+
+    #[cfg(not(target_family = "windows"))]
+        let pid = get_current_pid().unwrap();
+    #[cfg(target_family = "windows")]
+        let pid = get_current_pid().unwrap() as i32;
+
+    let args_str: Vec<String> = Vec::new();
+    let scheme = if args.is_present("no-tls") {
+        "http".to_string()
+    } else { "https".to_string() };
+    let pid_info = ServerInfo::new(pid, port, scheme, "Web Server".to_string(), current_process_name::get(), args_str);
+
+    //Serialize
+    let serialized = serde_json::to_string_pretty(&pid_info).unwrap();
+    let mut versions_file = File::create(&rymfony_pid_file).unwrap();
+
+    versions_file.write_all(serialized.as_bytes())
+        .expect("Could not write Process informations to JSON file.");
+
     proxy_server::start(
         !args.is_present("no-tls"),
         !args.is_present("allow-http"),
@@ -179,7 +229,9 @@ fn serve_background(args: &ArgMatches) {
         .expect("Failed to start server as a background process");
 
     let pid = subprocess.id();
-    let mut file = File::create(".pid").expect("Cannot create PID file");
+    let project_directory = get_rymfony_project_directory().expect("Unable to get Rymfony directory for this project");
+
+    let mut file = File::create(project_directory.join(".pid")).expect("Cannot create PID file");
     file.write_all(pid.to_string().as_ref())
         .expect("Cannot write to PID file");
 

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -1,20 +1,22 @@
 use clap::App;
 use clap::SubCommand;
 use std::fs;
-use std::path::Path;
 
 use crate::utils::stop_process;
+use crate::utils::project_directory::get_rymfony_project_directory;
 
 pub(crate) fn command_config<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("stop").about("Stops a potentially running HTTP server")
 }
 
 pub(crate) fn stop() {
-    if Path::new(".pid").exists() {
-        let pid = fs::read_to_string(".pid").unwrap();
+    let project_folder = get_rymfony_project_directory().expect("Unable to get Rymfony folder for this project");
+    let pid_path = project_folder.join(".pid");
+    if pid_path.exists() {
+        let pid = fs::read_to_string(&pid_path).unwrap();
         stop_process::stop(pid.as_ref());
         info!("Stopped server running with PID {}", pid);
-        fs::remove_file(".pid").expect("Could not remove the PID file")
+        fs::remove_file(&pid_path).expect("Could not remove the PID file")
     } else {
         info!("Seems like server is not running");
     }

--- a/src/http/fastcgi_handler.rs
+++ b/src/http/fastcgi_handler.rs
@@ -11,7 +11,6 @@ use hyper::HeaderMap;
 use hyper::Response;
 use regex::Captures;
 use regex::Regex;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::convert::Infallible;
 use warp::host::Authority;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod utils {
     pub(crate) mod current_process_name;
     pub(crate) mod network;
     pub(crate) mod stop_process;
+    pub(crate) mod project_directory;
 }
 
 mod php {

--- a/src/php/php_server.rs
+++ b/src/php/php_server.rs
@@ -1,8 +1,12 @@
+use std::fs::File;
+use std::io::Write;
+
 use crate::php::binaries;
 use crate::php::server_cgi::start as start_cgi;
 use crate::php::server_fpm::start as start_fpm;
 use crate::php::server_native::start as start_native;
-use crate::php::structs::PhpServerSapi;
+use crate::php::structs::{PhpServerSapi, ServerInfo};
+use crate::utils::project_directory::get_rymfony_project_directory;
 #[cfg(not(target_os = "windows"))]
 use crate::utils::stop_process;
 
@@ -11,6 +15,7 @@ use std::thread;
 use std::time;
 use std::path::PathBuf;
 use is_executable::IsExecutable;
+use std::str::FromStr;
 
 pub(crate) struct PhpServer {
     port: u16,
@@ -44,11 +49,11 @@ pub(crate) fn start() -> PhpServer {
 
     let (php_server, mut process) =
         if php_bin.contains("-fpm") && cfg!(not(target_family = "windows")) {
-            start_fpm(php_bin)
+            start_fpm(php_bin.clone())
         } else if php_bin.contains("-cgi") {
-            start_cgi(php_bin)
+            start_cgi(php_bin.clone())
         } else {
-            start_native(php_bin)
+            start_native(php_bin.clone())
         };
 
     let sleep_time = time::Duration::from_millis(1000);
@@ -67,14 +72,16 @@ pub(crate) fn start() -> PhpServer {
         )),
     }
 
+    let process_pid = process.id();
+
     ctrlc::set_handler(move || {
         info!("Stopping PHP process... ");
 
         #[cfg(not(target_os = "windows"))]
-        {
-            let pid = process.id();
-            stop_process::stop(pid.to_string().as_ref()); // Stop fpm children
-        }
+            {
+                let pid = process.id();
+                stop_process::stop(pid.to_string().as_ref()); // Stop fpm children
+            }
 
         match process.kill() {
             Ok(_) => info!("PHP process stopped."),
@@ -82,7 +89,24 @@ pub(crate) fn start() -> PhpServer {
         }
         process::exit(0);
     })
-    .expect("Error setting Ctrl-C handler");
+        .expect("Error setting Ctrl-C handler");
+
+    let args_str: Vec<String> = Vec::new();
+    let pidstr = if process_pid > 0 {
+        process_pid.to_string()
+    } else { "0".to_string() };
+
+    let pid_info = ServerInfo::new(i32::from_str(pidstr.as_str()).unwrap(), php_server.port, "".to_string(), format!("{}", php_server.sapi), php_bin.clone(), args_str);
+
+    //Serialize
+    let serialized = serde_json::to_string_pretty(&pid_info).unwrap();
+    let path = get_rymfony_project_directory().unwrap();
+    let server_pid_file = path.join("server.pid");
+    let mut versions_file = File::create(&server_pid_file).unwrap();
+
+    versions_file.write_all(serialized.as_bytes())
+        .expect("Could not write Process information to JSON file.");
+
 
     php_server
 }

--- a/src/php/server_cgi.rs
+++ b/src/php/server_cgi.rs
@@ -3,16 +3,15 @@ use crate::php::structs::PhpServerSapi;
 use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
-use dirs::home_dir;
 use std::fs::File;
+use crate::utils::project_directory::get_rymfony_project_directory;
 
 const CGI_DEFAULT_PORT: u16 = 65535;
 
 pub(crate) fn start(php_bin: String) -> (PhpServer, Child) {
     let mut command = Command::new(php_bin);
 
-    let error_log_file = home_dir().unwrap()
-        .join(".rymfony")
+    let error_log_file = get_rymfony_project_directory().unwrap()
         .join("php-cgi.log")
     ;
 

--- a/src/php/server_fpm.rs
+++ b/src/php/server_fpm.rs
@@ -1,20 +1,28 @@
 #[cfg(not(target_family = "windows"))]
-use std::{env, fs::File, io::prelude::*, process::Command, path::PathBuf};
-
+use std::{fs::File, io::prelude::*, process::Command};
+#[cfg(not(target_family = "windows"))]
+use std::error::Error;
+#[cfg(not(target_family = "windows"))]
+use std::fmt;
+#[cfg(not(target_family = "windows"))]
+use std::fs::{read_to_string, remove_file};
+use std::process::Child;
+#[cfg(not(target_family = "windows"))]
+use std::process::Stdio;
+#[cfg(not(target_family = "windows"))]
+use regex::{Regex, RegexBuilder};
 #[cfg(not(target_family = "windows"))]
 use users::{get_current_gid, get_current_uid};
+#[cfg(not(target_family = "windows"))]
+use wsl::is_wsl;
 
-use crate::php::php_server::PhpServer;
 #[cfg(not(target_family = "windows"))]
 use crate::{php::structs::PhpServerSapi};
+use crate::php::php_server::PhpServer;
 #[cfg(not(target_family = "windows"))]
 use crate::utils::network::find_available_port;
 #[cfg(not(target_family = "windows"))]
-use std::process::Stdio;
-use std::process::Child;
-
-#[cfg(not(target_family = "windows"))]
-use wsl::is_wsl;
+use crate::utils::project_directory::get_rymfony_project_directory;
 
 // Possible values: alert, error, warning, notice, debug
 #[cfg(not(target_family = "windows"))]
@@ -44,6 +52,7 @@ daemonize = no
 ;user = {{ uid }}
 ;group = {{ gid }}
 
+; Don't touch this line unless you know what you are doing
 listen = 127.0.0.1:{{ port }}
 listen.allowed_clients = 127.0.0.1
 
@@ -84,7 +93,7 @@ pub(crate) fn start(php_bin: String) -> (PhpServer, Child) {
     let gid = get_current_gid();
     let gid_str = gid.to_string();
 
-    let port = find_available_port(FPM_DEFAULT_PORT);
+    let mut port = find_available_port(FPM_DEFAULT_PORT);
 
     // TODO systemd support should be detected dynamically on Linux
     let systemd_support = !cfg!(target_os = "macos") && !is_wsl();
@@ -96,26 +105,37 @@ pub(crate) fn start(php_bin: String) -> (PhpServer, Child) {
         .replace("{{ log_level }}", FPM_DEFAULT_LOG_LEVEL)
         .replace("{{ systemd }}", if systemd_support { "" } else { ";" });
 
-    let home = env::var("HOME").unwrap_or(String::from(""));
-
-    let fpm_config_file_path;
-
-    if home != "" {
-        fpm_config_file_path = PathBuf::from(home.as_str())
-            .join(".rymfony")
-            .join("fpm-conf.ini");
-    } else {
-        panic!("Cannot find the \"HOME\" directory in which to write the php-fpm configuration file.");
-    }
+    let rymfony_project_path = match get_rymfony_project_directory() {
+        Ok(e) => e,
+        _ => panic!("Cannot find the \"HOME\" directory in which to write the php-fpm configuration file.")
+    };
+    let fpm_config_file_path = rymfony_project_path.join("fpm-conf.ini");
 
     if !fpm_config_file_path.exists() {
         let mut fpm_config_file = File::create(&fpm_config_file_path).unwrap();
         fpm_config_file.write_all(config.as_bytes())
-             .expect("Could not write to php-fpm config file.");
+            .expect("Could not write to php-fpm config file.");
+    } else {
+        // Read the file and search the port
+        let mut content = read_to_string(&fpm_config_file_path).unwrap();
+
+        let port_used = match read_port(&content) {
+            Ok(read_port) => read_port,
+            _ => port,
+        };
+
+        let port_checked = find_available_port(port_used);
+        content = change_port(&content, &port_checked);
+        port = port_checked;
+
+        remove_file(&fpm_config_file_path).expect("Could not remove php-fpm config file");
+        let mut fpm_config_file = File::create(&fpm_config_file_path).unwrap();
+        fpm_config_file.write_all(content.as_bytes())
+            .expect(format!("Could not write to php-fpm config file {}.", &fpm_config_file_path.to_str().unwrap()).as_str());
     }
 
-    let cwd = env::current_dir().unwrap();
-    let pid_filename = format!("{}/.fpm.pid", cwd.to_str().unwrap());
+
+    let pid_filename = format!("{}/fpm.pid", rymfony_project_path.to_str().unwrap());
 
     let mut command = Command::new(php_bin);
     command
@@ -134,4 +154,115 @@ pub(crate) fn start(php_bin: String) -> (PhpServer, Child) {
     }
 
     panic!("Could not start php-fpm.");
+}
+#[cfg(not(target_family = "windows"))]
+#[derive(Debug)]
+struct ReadPortError(String);
+
+#[cfg(not(target_family = "windows"))]
+impl fmt::Display for ReadPortError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "An error occured: {}", self.0)
+    }
+}
+#[cfg(not(target_family = "windows"))]
+impl Error for ReadPortError {}
+
+#[cfg(not(target_family = "windows"))]
+fn read_port(content: &str) -> std::result::Result<u16, ReadPortError> {
+    let re = RegexBuilder::new(r"^[ ]*listen[ ]?=[ ]?(.*)$").multi_line(true).build().unwrap();
+    let regex_port = Regex::new(r"^(?:(?:127\.0\.0\.1|localhost):)?(\d{1,5})").unwrap();
+
+    let mut found = false;
+    let mut read_port = "".to_string();
+    for caps in re.captures_iter(content) {
+        let captures = regex_port.captures(&caps[1]);
+        if !captures.is_none() && !found {
+            found = true;
+            let capss = captures.unwrap();
+            read_port = format!("{}", &capss[1]);
+        }
+    }
+    if !found {
+        return Err(ReadPortError("Unable to found port".into()));
+    }
+
+    let port_num: u16 = read_port.parse().unwrap();
+    Ok(port_num)
+}
+
+#[cfg(not(target_family = "windows"))]
+fn change_port(original_content: &str, new_port: &u16) -> String {
+    let re = RegexBuilder::new(r"^([ ]*listen[ ]?=[ ]?)(.*)$").multi_line(true).build().unwrap();
+    let regex_port = Regex::new(r"^((?:(?:127\.0\.0\.1|localhost):)?)(\d{1,5})").unwrap();
+
+    let mut found = false;
+    let mut content = original_content.to_string();
+    for caps in re.captures_iter(original_content) {
+        let captures = regex_port.captures(&caps[2]);
+        if captures.is_none() || found {
+            content = content.replace(&caps[0], format!(";{}", &caps[0]).as_str());
+        }
+        if !captures.is_none() && !found {
+            found = true;
+            let capss = captures.unwrap();
+            content = content.replace(&caps[0], format!("{}{}{}", &caps[1], &capss[1], new_port.to_string()).as_str());
+        }
+    }
+    if !found {
+        content = format!("{}\nlisten = 127.0.0.1:{}", content, new_port.to_string());
+    }
+
+    content
+}
+
+#[cfg(not(target_family = "windows"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn change_port_one_line() {
+        let str = "listen=1245";
+        let port = 2316;
+        let result = change_port(&str, &port);
+        assert_eq!(result.as_str(), "listen=2316");
+    }
+    #[test]
+    fn change_port_multiple_line() {
+        let str = "
+        listen = 127.0.0.1:1245
+        ";
+        let port = 2316;
+        let result = change_port(&str, &port);
+        assert_eq!(result.as_str(), "
+        listen = 127.0.0.1:2316
+        ");
+    }
+    #[test]
+    fn change_port_multiple_listen() {
+        let str = "
+listen = 127.0.0.1:1245
+listen = 127.0.0.1:158
+listen =localhost:18
+        ";
+        let port = 2316;
+        let result = change_port(&str, &port);
+        assert_eq!(result.as_str(), "
+listen = 127.0.0.1:2316
+;listen = 127.0.0.1:158
+;listen =localhost:18
+        ");
+    }
+    #[test]
+    fn change_port_listen_socket() {
+        let str = "
+listen = /path/to/socket
+        ";
+        let port = 2316;
+        let result = change_port(&str, &port);
+        assert_eq!(result.as_str(), "
+;listen = /path/to/socket
+        \nlisten = 127.0.0.1:2316");
+    }
 }

--- a/src/php/structs.rs
+++ b/src/php/structs.rs
@@ -1,12 +1,13 @@
-use regex::Regex;
+use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
-use serde::Serializer;
-use serde::Serialize;
+
+use regex::Regex;
+use serde::de::{Deserialize, Deserializer, Error, Visitor};
 use serde::Deserialize as SerdeDeserialize;
-use serde::de::{Deserialize, Deserializer, Visitor, Error};
-use std::fmt;
+use serde::Serialize;
+use serde::Serializer;
 
 #[derive(Debug)]
 pub(crate) enum PhpServerSapi {
@@ -95,7 +96,7 @@ impl PhpVersion {
     pub(crate) fn version(&self) -> &str {
         self._version.as_str()
     }
-    }
+}
 
 impl Serialize for PhpVersion {
     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error> where
@@ -114,7 +115,6 @@ impl<'de> Deserialize<'de> for PhpVersion {
 struct PhpVersionVisitor;
 
 impl<'de> Visitor<'de> for PhpVersionVisitor {
-
     type Value = PhpVersion;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -127,7 +127,6 @@ impl<'de> Visitor<'de> for PhpVersionVisitor {
     {
         Ok(PhpVersion::from_str(value))
     }
-
 }
 
 //
@@ -147,7 +146,7 @@ pub(crate) struct PhpBinary {
     cgi: String,
     system: bool,
     #[serde(skip_serializing)]
-    #[serde(default="PhpVersion::new")]
+    #[serde(default = "PhpVersion::new")]
     _version: PhpVersion,
 }
 
@@ -226,7 +225,7 @@ impl PhpBinary {
             }
             PhpServerSapi::Unknown => {
                 panic!("Unknown sapi \"{}\" at path \"{}\"", &sapi, &path);
-            },
+            }
         }
     }
 
@@ -238,4 +237,55 @@ impl PhpBinary {
             PhpServerSapi::Unknown => String::from(""),
         }
     }
+}
+
+
+//
+//
+//
+//
+//
+//
+//
+//
+
+
+#[derive(Hash, Eq, PartialEq, Debug, Serialize, SerdeDeserialize)]
+pub(crate) struct ServerInfo {
+    pid: i32,
+    port: u16,
+    scheme: String,
+    name: String,
+    command: String,
+    args: Vec<String>,
+}
+
+impl Display for ServerInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "pid: {}, port: {}, scheme: {}, name: {}, command: {}, args: {}", self.pid, self.port, self.scheme, self.name, self.command, self.args.join(" "))
+    }
+}
+
+impl ServerInfo {
+    pub(crate) fn new(pid: i32, port: u16, scheme: String, name: String, command: String, args: Vec<String>) -> ServerInfo {
+        ServerInfo {
+            pid,
+            port,
+            scheme: scheme.clone(),
+            name: name.clone(),
+            command: command.clone(),
+            args: args.clone(),
+        }
+    }
+    pub(crate) fn pid(&self) -> i32 {
+        self.pid
+    }
+    pub(crate) fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub(crate) fn scheme(&self) ->String{
+        self.scheme.clone()
+    }
+
 }

--- a/src/utils/project_directory.rs
+++ b/src/utils/project_directory.rs
@@ -1,0 +1,46 @@
+use std::{env, path::PathBuf};
+use std::error::Error;
+use std::fmt;
+use std::fs::create_dir;
+use std::result::Result;
+
+use dirs::home_dir;
+use sha2::Digest;
+
+#[derive(Debug)]
+struct ProjectDirectoryError(String);
+
+impl fmt::Display for ProjectDirectoryError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "An error occured: {}", self.0)
+    }
+}
+
+impl Error for ProjectDirectoryError {}
+
+pub(crate) fn get_rymfony_project_directory() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let home = home_dir().unwrap().display().to_string();
+    let homestr = home.as_str();
+
+
+
+    if homestr != "" {
+        let cwd = env::current_dir().unwrap();
+
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(&cwd.to_str().unwrap().as_bytes());
+        let hash = hasher.finalize();
+
+        let rymfony_project_path = PathBuf::from(homestr)
+            .join(".rymfony")
+            .join(format!("{:x}", hash));
+
+        if !rymfony_project_path.is_dir() {
+            create_dir(&rymfony_project_path).expect(format!("Unable to make directory for project {}", rymfony_project_path.to_str().unwrap()).as_str());
+        }
+
+        return Ok(rymfony_project_path);
+    }
+
+    Err(Box::new(ProjectDirectoryError("Cannot find the \"HOME\" directory".into())))
+}


### PR DESCRIPTION
This PR is a proposal of my vision how manage the FPM port from configuration.

* If config file does'nt exist, create it
* If config file is found, read the port
    * If unable to read port, use the next available (when if file does'nt exists)
    * If read succes, check if port is available (change if not available)
* Change the port into the config file
    * If multi line `listen`, comment all line less one. Update the first matching.
    * If no line is vailable to update, add new line at the end of file.